### PR TITLE
Add CHIP-2021-05-vm-limits: Targeted Virtual Machine Limits

### DIFF
--- a/app/data/chips.json
+++ b/app/data/chips.json
@@ -1,5 +1,13 @@
 {
   "chips": [
+     {
+      "title": "CHIP-2021-05-vm-limits: Targeted Virtual Machine Limits",
+      "lastUpdated": "2021/05/12",
+      "link": "https://github.com/bitjson/bch-vm-limits",
+      "consensus": "Yes",
+      "tags": "",
+      "activated": "No"
+    },
     {
       "title": "CHIP 2021-07 UTXO Fastsync",
       "lastUpdated": "2021/07/07",


### PR DESCRIPTION
Found this CHIP was missing, it is needed by the Bounded Loops CHIP.