### PR TITLE
Replace LocalBitcoinCash with LocalCryptos

### DIFF
--- a/app/data/exchanges.json
+++ b/app/data/exchanges.json
@@ -73,8 +73,8 @@
       "link": "https://www.bitstamp.net/"
     },
     {
-      "name": "LocalBitcoinCash",
-      "link": "https://www.localbitcoincash.org/"
+      "name": "LocalCryptos",
+      "link": "https://localcryptos.com/"
     },
     {
       "name": "BestRate",


### PR DESCRIPTION
LBC has been dead for a while, LocalCryptos took over local.bitcoincom's operations and I've been using them for a while