### PR TITLE
Remove text about BU node count popularity

### DIFF
--- a/lang/en/nodes.yaml
+++ b/lang/en/nodes.yaml
@@ -4,7 +4,7 @@ sub: Be part of the network by running a full node
 recommended:
   title: Recommended node for miners
   bchn: <b>Bitcoin Cash Node</b> is a professional and miner-friendly node.
-  bu: <b>Bitcoin Unlimited</b> is currently the most popular Bitcoin Cash node by count.
+  bu: <b>Bitcoin Unlimited</b> is another popular Bitcoin Cash node by count.
   btn: Go to website
 
 popular:


### PR DESCRIPTION
BU is no longer the most popular node and text should reflect accordingly

![image](https://user-images.githubusercontent.com/34949601/200435896-e7284114-b74c-42bc-8698-360587b91a70.png)
