### PR TITLE
Coinbase wallet removes BCH support

### DIFF
--- a/app/wallets.html
+++ b/app/wallets.html
@@ -23,7 +23,6 @@
         <a class="d-block" href="https://wallet.bitcoin.com" target="_blank">Bitcoin.com Wallet</a>
         <a class="d-block" href="https://electroncash.org" target="_blank">Electron Cash</a>
         <a class="d-block" href="https://bitpay.com/wallet" target="_blank">BitPay</a>
-        <a class="d-block" href="https://wallet.coinbase.com" target="_blank">Coinbase Wallet</a>
         <a class="d-block" href="https://edge.app" target="_blank">Edge</a>
         <a class="d-block" href="https://brd.com" target="_blank">BRD</a>
         <a class="d-block" href="https://melis.io" target="_blank">Melis Wallet</a>


### PR DESCRIPTION
See also: https://techstory.in/crypto-wallet-coinbase-stoping-bch-etc-xlm-and-xrp-support-citing-low-usage/