### PR TITLE
Add Coin Wallet to the list of wallets

### DIFF
--- a/app/wallets.html
+++ b/app/wallets.html
@@ -34,6 +34,7 @@
         <a class="d-block" href="https://melis.io" target="_blank">Melis</a>
         <a class="d-block" href="https://stackwallet.com/" target="_blank">Stack Wallet</a>
         <a class="d-block" href="https://zapit.io" target="_blank">Zapit</a>
+        <a class="d-block" href="https://coin.space/" target="_blank">Coin Wallet</a>
       </div>
 
       <!-- Desktop -->
@@ -44,6 +45,7 @@
         <a class="d-block" href="https://flowee.org/products/pay/" target="_blank">Flowee Pay (Linux only)</a>
         <a class="d-block" href="https://chromewebstore.google.com/detail/paytaca/pakphhpnneopheifihmjcjnbdbhaaiaa" target="_blank">Paytaca (Chrome only)</a>
         <a class="d-block" href="https://melis.io" target="_blank">Melis</a>
+        <a class="d-block" href="https://coin.space/" target="_blank">Coin Wallet</a>
       </div>
 
       <!-- Hardware -->
@@ -70,6 +72,7 @@
         <p class="lead">$( wallets.browser.sub )$</p>
         <a class="d-block" href="https://cashonize.com/" target="_blank">Cashonize</a>
         <a class="d-block" href="https://wallet.melis.io/" target="_blank">Melis</a>
+        <a class="d-block" href="https://coin.space/" target="_blank">Coin Wallet</a>
       </div>
 
     </div>


### PR DESCRIPTION
Could you please add Coin Wallet to the list of wallets?

Coin Wallet is a non-custodial multicurrency crypto wallet. 

It's an open-source wallet, and the code is available here: https://github.com/CoinSpace/CoinSpace

Coin Wallet is available as a web wallet, a mobile wallet (iOS & Android), and desktop apps (Windows, Linux & MacOS).
