### PR TITLE
remove bitcoincom exchange

### DIFF
--- a/app/data/exchanges.json
+++ b/app/data/exchanges.json
@@ -81,10 +81,6 @@
       "link": "https://coinfalcon.com/"
     },
     {
-      "name": "Bitcoin.com",
-      "link": "https://exchange.bitcoin.com/"
-    },
-    {
       "name": "Gemini",
       "link": "https://gemini.com/exchange"
     },


### PR DESCRIPTION
It now redirects to Verse, which is an EVM dex with no way to directly buy mainchain BCH. The sBCH part is no longer relevant.