### PR TITLE
Remove evercoin.com, add electroncash.de explorer

### DIFF
--- a/app/data/exchanges.json
+++ b/app/data/exchanges.json
@@ -37,10 +37,6 @@
       "link": "https://www.alfacashier.com/"
     },
     {
-      "name": "Evercoin",
-      "link": "https://evercoin.com/"
-    },
-    {
       "name": "Coinone",
       "link": "https://coinone.co.kr/"
     },

--- a/app/explorers.html
+++ b/app/explorers.html
@@ -24,6 +24,10 @@
     link: "https://explorer.bitcoinunlimited.info"
   },
   {
+    name: "Electroncash.de Explorer",
+    link: "https://explorer.electroncash.de"
+  },
+  {
     name: "Bitcoin Verde",
     link: "https://explorer.bitcoinverde.org"
   },


### PR DESCRIPTION
Evercoin returns SEC_ERROR_REVOKED_CERTIFICATE

https://explorer.electroncash.de is another explorer