### PR TITLE
Restore banner for 2024 upgrade

### DIFF
--- a/app/templates/base.njk
+++ b/app/templates/base.njk
@@ -54,15 +54,15 @@
 </head>
 <body>
   <!-- Banner -->
-  {# <div class="bg-dark">
+  <div class="bg-dark">
     <div class="bg-info-gradient py-2">
-      <a href="#">
+      <a href="/$( _lang_ )$/upgrade">
         <div class="container text-center text-white">
-          
+          Prepare for the May 15th, 2024 network upgrade!
         </div>
       </a>
     </div>
-  </div> #}
+  </div>
 
   <!-- Body -->
   {% block body %}{% endblock %}

--- a/app/upgrade.html
+++ b/app/upgrade.html
@@ -1,4 +1,4 @@
-{% extends 'base.njk' %} {% block title %}May 15th, 2023 Bitcoin Cash network
+{% extends 'base.njk' %} {% block title %}May 15th, 2024 Bitcoin Cash network
 upgrade{% endblock %} {% block body %}
 
 <section class="hero-alt">

--- a/app/upgrade.html
+++ b/app/upgrade.html
@@ -1,15 +1,12 @@
-{% extends 'base.njk' %}
-
-{% block title %}May 15th, 2023 Bitcoin Cash network upgrade{% endblock %}
-
-{% block body %}
+{% extends 'base.njk' %} {% block title %}May 15th, 2023 Bitcoin Cash network
+upgrade{% endblock %} {% block body %}
 
 <section class="hero-alt">
   {% include "navbar.njk" %}
 
   <div class="container py-6 text-white text-center text-md-left">
     <h1 class="display-5 font-weight-bold">
-      May 15th, 2023<br>
+      May 15th, 2023<br />
       Bitcoin Cash network upgrade
     </h1>
   </div>
@@ -22,21 +19,40 @@
         <h6 class="font-weight-bold mb-4">Changelog:</h6>
 
         <ol>
-          <li>Most notably, the Cashtokens upgrade which enables advanced abstraction in script and covenant designs, as well as conventional token and NFT usecases.</li>
-
-          <li>P2SH32, which allows for more cryptographically secure transactions.</li>
-
-          <li>Other minor improvements that cleans up the ruleset.</li>
+          <li>
+            The only significant change this cycle is the Adaptive Blocksize
+            Limit Algorithm. Read more
+            <a href="https://gitlab.com/0353F40E/ebaa/-/blob/main/README.md"
+              >here</a
+            >.
+          </li>
         </ol>
 
-        <h6 class="font-weight-bold mb-4 mt-5">For node operators, upgrade to the latest version of a compatible node:</h6>
+        <h6 class="font-weight-bold mb-4 mt-5">
+          For node operators, upgrade to the latest version of a compatible
+          node:
+        </h6>
 
         <ul>
-          <li>Compatible, released: <a href="https://bitcoincashnode.org/" target="_blank">Bitcoin Cash Node</a>, <a href="https://kth.cash/" target="_blank">Knuth</a>, <a href="https://bitcoinverde.org/" target="_blank">Bitcoin Verde</a>, <a href="https://bitcoinunlimited.info/" target="_blank">Bitcoin Unlimited</a></li>
+          <li>
+            Compatible, released:
+            <a href="https://bitcoincashnode.org/" target="_blank"
+              >Bitcoin Cash Node</a
+            >
+          </li>
 
-          <li>Yet to release a compatible version: <a href="https://bchd.cash/" target="_blank">BCHD</a>, <a href="https://flowee.org/hub/" target="_blank">Flowee the Hub</a></li>
+          <li>
+            Yet to release a compatible version:
+            <a href="https://bchd.cash/" target="_blank">BCHD</a>,
+            <a href="https://flowee.org/hub/" target="_blank">Flowee the Hub</a
+            >, <a href="https://kth.cash/" target="_blank">Knuth</a>,
+            <a href="https://bitcoinverde.org/" target="_blank">Bitcoin Verde</a
+            >,
+            <a href="https://bitcoinunlimited.info/" target="_blank"
+              >Bitcoin Unlimited</a
+            >
+          </li>
         </ul>
-
       </div>
     </div>
   </div>

--- a/app/upgrade.html
+++ b/app/upgrade.html
@@ -6,7 +6,7 @@ upgrade{% endblock %} {% block body %}
 
   <div class="container py-6 text-white text-center text-md-left">
     <h1 class="display-5 font-weight-bold">
-      May 15th, 2023<br />
+      May 15th, 2024<br />
       Bitcoin Cash network upgrade
     </h1>
   </div>


### PR DESCRIPTION
The contents of the upgrade page need to be updated accordingly:

<img width="1310" alt="Screenshot 2024-02-03 at 23 25 30" src="https://github.com/bchinfo/bch.info/assets/21960643/7c9a8e1c-4385-4ac0-aa7d-19960f6d2ed7">

@imaginaryusername let me know when you have this ready so I can update this PR.