### PR TITLE
Request to add Tokenview BCH blockchain explorer api

### DIFF
--- a/app/developers.html
+++ b/app/developers.html
@@ -107,6 +107,11 @@
   name: "Coinremitter",
   link: "https://coinremitter.com/docs/api/v3/BCH",
   stacks: ["api"]
+},
+{
+  name: "Tokenview",
+  link: "https://services.tokenview.io/en/product/api/bch",
+  stacks: ["api"]
 }
 ] %}
 

--- a/app/explorers.html
+++ b/app/explorers.html
@@ -42,6 +42,10 @@
   {
     name: "Salem Kode's Bitcoin Cash Explorer",
     link: "https://explorer.salemkode.com/"
+  },
+  {
+    name: "Tokenview",
+    link: "https://bch.tokenview.io/"
   }
 ] %}
 


### PR DESCRIPTION
Tokenview supports [BCH blockchain explorer](https://bch.tokenview.io/en), BCH on-chain data and charts since 2018. Tokenview developer platform provides much [BCH node service APIs and blockchain APIs](https://services.tokenview.io/en/product/api/bch) for BCH eco developers. Request to add Tokenview in Explorer and Developer page.