### PR TITLE
Remove BTC.com and Electroncash.de from explorers

### DIFF
--- a/app/explorers.html
+++ b/app/explorers.html
@@ -24,14 +24,6 @@
     link: "https://www.blockchain.com/explorer?view=bch"
   },
   {
-    name: "BTC.com",
-    link: "https://bch.btc.com"
-  },
-  {
-    name: "Electroncash.de Explorer",
-    link: "https://explorer.electroncash.de"
-  },
-  {
     name: "BCH Explorer",
     link: "https://bchexplorer.cash/"
   },


### PR DESCRIPTION
These two links are also dead, unless you know a new url?